### PR TITLE
Add module retraction for v0.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,6 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/zclconf/go-cty v1.8.3
 )
+
+// Incorrect plugin registration for puppet provisioners; see hashicorp/packer-plugin-puppet/pull/11
+retract v0.0.1


### PR DESCRIPTION
The initial release of this plugin incorrectly registered the Puppet provisioners. This change adds a retraction for v0.0.1 of the packer-plugin-puppet module to inform potential consumers of this package (via go get ...) that they should use v0.0.2 and above.
